### PR TITLE
Add location fields to service requests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,23 +3,14 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '3.0.0'
 
-gem 'pg', '~> 1.1'
-gem 'puma', '~> 5.0'
-gem 'rails', '~> 6.1.3', '>= 6.1.3.2'
-# Use Redis adapter to run Action Cable in production
-# gem 'redis', '~> 4.0'
-# Use Active Model has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
-
-# Use Active Storage variant
-# gem 'image_processing', '~> 1.2'
-# gem "aws-sdk-s3", require: false
-
-
 gem 'bootsnap', '>= 1.4.4', require: false
 gem 'devise_token_auth'
+gem 'pg', '~> 1.1'
+gem 'puma', '~> 5.0'
 gem 'rack-cors'
+gem 'rails', '~> 6.1.3', '>= 6.1.3.2'
 gem 'state_machines-activerecord'
+# gem "aws-sdk-s3", require: false
 
 group :development, :test do
   gem 'coveralls', require: false

--- a/app/models/service_request.rb
+++ b/app/models/service_request.rb
@@ -25,4 +25,13 @@ class ServiceRequest < ApplicationRecord
       transition [:in_progress] => :finalized
     end
   end
+
+  def get_location
+    result = PostCodeService.get_location(location)
+    self.latitude = result[:latitude]
+    self.longitude = result[:longitude]
+    self.address = result[:"place name"]
+    save
+    [latitude, longitude]
+  end
 end

--- a/app/services/post_code_service.rb
+++ b/app/services/post_code_service.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rest-client'
+module PostCodeService
+  # URL = 'http://yourmoneyisnowmymoney.com/api/zipcodes'
+  URL = 'http://api.zippopotam.us/se/'
+  def self.get_location(post_code)
+    #response = JSON.parse(RestClient.get(URL, params: { zipcode: post_code }).body)    
+    response = JSON.parse(RestClient.get(URL + post_code.delete(' ')))
+    #response['results'].first.symbolize_keys
+    response['places'].first.symbolize_keys
+  end
+
+  def self.to_coordinates(post_code)
+    result = PostCodeService.get_location(post_code)
+    [result[:latitude].to_f, result[:longitude].to_f]
+  end
+end

--- a/db/migrate/20211101111237_add_location_fields_to_service_requests.rb
+++ b/db/migrate/20211101111237_add_location_fields_to_service_requests.rb
@@ -1,0 +1,7 @@
+class AddLocationFieldsToServiceRequests < ActiveRecord::Migration[6.1]
+  def change
+    add_column :service_requests, :address, :string
+    add_column :service_requests, :latitude, :float
+    add_column :service_requests, :longitude, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_01_105120) do
+ActiveRecord::Schema.define(version: 2021_11_01_111237) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -124,6 +124,9 @@ ActiveRecord::Schema.define(version: 2021_11_01_105120) do
     t.integer "time_frame"
     t.text "languages", default: [], array: true
     t.string "location"
+    t.string "address"
+    t.float "latitude"
+    t.float "longitude"
     t.index ["user_id"], name: "index_service_requests_on_user_id"
   end
 

--- a/spec/models/service_request_spec.rb
+++ b/spec/models/service_request_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe ServiceRequest, type: :model do
       it { is_expected.to have_db_column :time_frame }
       it { is_expected.to have_db_column :languages }
       it { is_expected.to have_db_column :location }
-      # it { is_expected.to have_db_column :address }
-      # it { is_expected.to have_db_column :latitude }
-      # it { is_expected.to have_db_column :longitude }
+      it { is_expected.to have_db_column :address }
+      it { is_expected.to have_db_column :latitude }
+      it { is_expected.to have_db_column :longitude }
     end
 
     describe 'associations' do

--- a/spec/models/service_request_spec.rb
+++ b/spec/models/service_request_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe ServiceRequest, type: :model do
       it { is_expected.to have_many :bids }
       it { is_expected.to have_one :deal }
     end
+
+    describe 'instance methods' do  
+      it { is_expected.to respond_to :get_location}
+    end
   end
 
   describe 'Enums' do


### PR DESCRIPTION
- Generate address, longitude, latitude columns to service requests table
- Comment in un commented tests
- adds get_location instance method to service_requests